### PR TITLE
Add tests and optional mplcursors

### DIFF
--- a/animations/prime_factor.py
+++ b/animations/prime_factor.py
@@ -138,7 +138,10 @@ class DualPrimeFactorProgression:
         return cont
 
 # --- static performance with hover tooltips
-import mplcursors
+try:
+    import mplcursors
+except ImportError:  # pragma: no cover - optional dependency for tooltips
+    mplcursors = None
 class PrimeFactorPerformance:
     def __init__(self, sizes, ax):
         self.sizes = sizes
@@ -174,6 +177,8 @@ class PrimeFactorPerformance:
     def _connect(self):
         def fmt(t):
             return f"{t*1000:.2f} ms" if t < 1.0 else f"{t:.3f} s"
+        if mplcursors is None:
+            return
 
         mplcursors.cursor(self.scat_naive, hover=True).connect(
             "add", lambda sel: sel.annotation.set_text(

--- a/tests/test_prime_factor.py
+++ b/tests/test_prime_factor.py
@@ -1,0 +1,12 @@
+import pytest
+
+from animations.prime_factor import naive_lpf, optimized_lpf, is_prime_naive, is_prime_opt
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 15, 21, 37, 97, 180])
+def test_lpf_agreement(n):
+    assert naive_lpf(n) == optimized_lpf(n)
+
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 4, 5, 18, 37, 97, 100])
+def test_is_prime_agreement(n):
+    assert is_prime_naive(n) == is_prime_opt(n)
+


### PR DESCRIPTION
## Summary
- add pytest-based tests for prime factorization helpers
- make mplcursors optional for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fc6b21f4832d9d315024f9d86ab0